### PR TITLE
add admin only component and wrap around admin page

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -7,6 +7,7 @@ import AIAssistant from "./components/AIAssistant";
 import SignIn from './components/SignIn';
 import SignUp from './components/SignUp';
 import AdminPage from './components/AdminPage';
+import AdminOnly from './components/AdminOnly';
 import './App.css';
 
 const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:5000';
@@ -202,7 +203,9 @@ function App() {
           <Route
             path="/admin"
             element={
-              <AdminPage />
+              <AdminOnly>
+                <AdminPage />
+              </AdminOnly>
             }
           />
         </Routes>

--- a/frontend/src/components/AdminOnly.js
+++ b/frontend/src/components/AdminOnly.js
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../supabaseClient';
+
+function AdminOnly({ children }) {
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const checkAdminStatus = async () => {
+      const { data, error } = await supabase.rpc('get_my_claim', {
+        claim: 'role' 
+      });
+
+      if (error) {
+        console.error('Error checking admin status:', error);
+      }
+      
+      if (data === 'admin') {
+        setIsAdmin(true);
+      }
+
+      setLoading(false);
+    };
+
+    checkAdminStatus();
+  }, []);
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <>
+      {isAdmin ? children : <div>You do not have permission to view this page.</div>}
+    </>
+  );
+}
+
+export default AdminOnly;
+
+// --- HOW TO USE IN ANOTHER COMPONENT ---
+
+// import AdminOnly from './AdminOnly';
+// import AdminDashboard from './AdminDashboard';
+
+// function App() {
+//   return (
+//     <div>
+//       <h1>My Awesome App</h1>
+//       <p>Some public content here.</p>
+//
+//       <AdminOnly>
+//         {/* This will only be rendered if the user is an admin */}
+//         <AdminDashboard />
+//       </AdminOnly>
+//     </div>
+//   );
+// }


### PR DESCRIPTION
This admin-only component can be used to verify admin users by checking the Supabase custom claims roles.
To add admin users, you must do so through the Supabase dashboard client.
To use the component, just wrap it around any admin-only page you wish to protect, and it will check if the user loading the page is an admin; if not, then it will not load the page.